### PR TITLE
Update multistr to version 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parse-hosts"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Clar Charr <clar@charr.xyz>"]
 repository = "https://github.com/clarcharr/parse-hosts"
 documentation = "https://clarcharr.github.io/parse-hosts/parse_hosts"
@@ -10,7 +10,7 @@ license-file = "LICENSE"
 exclude = [".gitignore"]
 
 [dependencies]
-multistr = "0.2"
+multistr = "0.4"
 
 [dev-dependencies]
 clippy = "^0.0"

--- a/src/data_line.rs
+++ b/src/data_line.rs
@@ -133,7 +133,7 @@ impl FromStr for DataLine {
                 if let Some(idx) = host.find(INVALID_CHARS) {
                     return Err(DataParseError::BadHost(host[idx..].chars().next().unwrap(),
                                                        host.to_owned()));
-                } else if let Ok(ipv4) = host.parse(): Result<Ipv4Addr, _> {
+                } else if let Ok(ipv4) = host.parse::<Ipv4Addr>() {
                     return Err(DataParseError::HostWasIp(ipv4));
                 } else {
                     hosts.push(host);

--- a/src/data_line.rs
+++ b/src/data_line.rs
@@ -4,7 +4,7 @@ use std::fmt;
 use std::net::{AddrParseError, IpAddr, Ipv4Addr};
 use std::str::FromStr;
 use multistr::StringVec;
-use multistr::vec::Iter as SVIter;
+use multistr::Iter as SVIter;
 
 /// Characters which aren't allowed in URLs.
 static INVALID_CHARS: &[char] = &['\0', '\u{0009}', '\u{000a}', '\u{000d}', '\u{0020}', '#', '%',
@@ -45,7 +45,7 @@ pub fn minify_lines(lines: &mut Vec<DataLine>) {
     for (ip, mut hosts) in min {
         hosts.sort();
         hosts.dedup();
-        lines.push(DataLine::from_raw(ip, hosts.iter().collect()));
+        lines.push(DataLine::from_raw(ip, hosts.iter().map(|s| &**s).collect()));
     }
 }
 
@@ -56,7 +56,7 @@ pub fn empty_hosts() -> Hosts<'static> {
 
 /// Iterator over the hosts on a line.
 pub struct Hosts<'a> {
-    inner: Option<SVIter<'a>>,
+    inner: Option<SVIter<'a, str>>,
 }
 impl<'a> Iterator for Hosts<'a> {
     type Item = &'a str;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(type_ascription)]
 #![cfg_attr(test, feature(plugin))]
 #![cfg_attr(test, plugin(clippy))]
 


### PR DESCRIPTION
This is a breaking change because `multistr::StringVec` is exposed in the public API `DataLine::from_raw`.

Submitting since I already have the patch, but no need to publish this on crate.io just yet since I’d like to update to 0.5 soon with https://github.com/clarcharr/multistr/pull/2.