### PR TITLE
Remove premature use of trait bounds on type aliases

### DIFF
--- a/src/hosts_file.rs
+++ b/src/hosts_file.rs
@@ -7,7 +7,7 @@ use super::{DataLine, DataParseError, Line, IntoPairs};
 use super::data_line::empty_pairs;
 
 /// Shorthand for `HostsFile<BufReader<R>>`.
-pub type BufHostsFile<R: Read> = HostsFile<BufReader<R>>;
+pub type BufHostsFile<R> = HostsFile<BufReader<R>>;
 
 /// Shorthand for `HostsFile<BufReader<File>>`.
 pub type ActualHostsFile = HostsFile<BufReader<File>>;


### PR DESCRIPTION
```
warning[E0122]: trait bounds are not (yet) enforced in type definitions
  --> /Users/nox/.cargo/registry/src/github.com-1ecc6299db9ec823/parse-hosts-0.4.0/src/hosts_file.rs:10:1
   |
10 | pub type BufHostsFile<R: Read> = HostsFile<BufReader<R>>;
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```